### PR TITLE
🐛  Fix bug where author images were not showing up in research theme cards

### DIFF
--- a/src/app/homepage/ResearchThemesSection.tsx
+++ b/src/app/homepage/ResearchThemesSection.tsx
@@ -58,8 +58,11 @@ const GatherStatsByResearchTopic = () => {
         .flatMap(publication => publication.authors[0])
         .concat(filteredPublications.flatMap(publication => publication.authors.slice(1)))
     )
-    const filteredAuthors: Member[] = topicAuthors.flatMap(author => {
-      return Object.values(MEMBERS).filter(member => member.img && `${member.firstName} ${member.lastName}` === author)
+    const filteredAuthors: Member[] = topicAuthors.filter(entry => {
+      if (entry instanceof Object && entry.isAlumni !== true) {
+        // TODO: Optimize this condition
+        return entry
+      }
     })
 
     statsByResearchTopic[researchTopicKey] = { numPublications, authors: filteredAuthors }


### PR DESCRIPTION
Fixed missing avatar images bug in research themes section.
NOTE: It'll probably be best to rework the filtering algorithm. Currently, it disregards all alumni as they do not have photos.
![Screenshot 2024-10-24 at 7 18 07 PM](https://github.com/user-attachments/assets/507fd1f4-4e03-4df1-bdbe-af18d5a30ede)

