### PR TITLE
Display a member's position and affiliation conditionally

### DIFF
--- a/src/components/MemberCard.tsx
+++ b/src/components/MemberCard.tsx
@@ -116,7 +116,11 @@ export const MemberCard = ({ member }: Props) => {
         <Name>
           {member.firstName} {member.lastName}
         </Name>
-        <Affiliation>{member.affiliation || member.kixlabPosition}</Affiliation>
+        <Affiliation>
+          {member.displayedPosition ||
+            ((member.kixlabPosition === 'Visiting Researcher' || member.kixlabPosition === 'Undergrad Intern') &&
+              member.affiliation)}
+        </Affiliation>
         <Buttons>
           {member.email && <EmailButton href={`mailto:${member.email}`} />}
           {member.site && <WebsiteButton href={member.site} target="_blank" rel="noopener noreferrer" />}

--- a/src/components/MemberCard.tsx
+++ b/src/components/MemberCard.tsx
@@ -117,7 +117,7 @@ export const MemberCard = ({ member }: Props) => {
           {member.firstName} {member.lastName}
         </Name>
         <Affiliation>
-          {member.displayedPosition ||
+          {member.currentPosition ||
             ((member.kixlabPosition === 'Visiting Researcher' || member.kixlabPosition === 'Undergrad Intern') &&
               member.affiliation)}
         </Affiliation>

--- a/src/data/members.ts
+++ b/src/data/members.ts
@@ -17,18 +17,17 @@ interface Props {
   lastName: string
   email?: string
   kixlabPosition: KixlabPositionTypes
-  displayedPosition?: string
   img?: string
   site?: string
   msThesis?: string
   phdThesis?: string
-  affiliation?: string
   // TODO: combine startYear and startSeason into a single Date field: startDate
   startYear?: number
   startSeason?: SeasonType
   endYear?: number
   endSeason?: SeasonType
   isAlumni?: boolean
+  affiliation?: string // for alumni
   currentPosition?: string // for alumni
 }
 
@@ -175,7 +174,7 @@ export const MEMBERS = {
     lastName: 'Kim',
     email: 'juhokim@kaist.ac.kr',
     kixlabPosition: 'Faculty',
-    displayedPosition: 'Associate Professor',
+    currentPosition: 'Associate Professor',
     img: 'juhokim.jpg',
     site: 'http://juhokim.com/',
     startYear: 2016,

--- a/src/data/members.ts
+++ b/src/data/members.ts
@@ -27,7 +27,7 @@ interface Props {
   endYear?: number
   endSeason?: SeasonType
   isAlumni?: boolean
-  affiliation?: string // for alumni
+  affiliation?: string // the affiliation at the time of being at KIXLAB
   currentPosition?: string // for alumni
 }
 

--- a/src/data/members.ts
+++ b/src/data/members.ts
@@ -17,6 +17,7 @@ interface Props {
   lastName: string
   email?: string
   kixlabPosition: KixlabPositionTypes
+  displayedPosition?: string
   img?: string
   site?: string
   msThesis?: string
@@ -174,6 +175,7 @@ export const MEMBERS = {
     lastName: 'Kim',
     email: 'juhokim@kaist.ac.kr',
     kixlabPosition: 'Faculty',
+    displayedPosition: 'Associate Professor',
     img: 'juhokim.jpg',
     site: 'http://juhokim.com/',
     startYear: 2016,


### PR DESCRIPTION
- Add an optional field called 'displayed position' to Member props. (To show Juho's position as Associate Professor)
- Add conditions to show positions & affiliations (No display for regular members, show affiliations for interns / visiting researchers)