### PR TITLE
Support multiple engagement periods for alumni

### DIFF
--- a/src/components/AlumniCard.tsx
+++ b/src/components/AlumniCard.tsx
@@ -85,9 +85,20 @@ export const AlumniCard = ({ mem }: { mem: Member }) => {
           </Name>
         )}
         {mem.affiliation && <Education>{mem.affiliation}</Education>}
-        <Period>
-          {mem.startSeason} {mem.startYear} {mem.endSeason && mem.endYear ? ` - ${mem.endSeason} ${mem.endYear}` : ''}
-        </Period>
+        {Array.isArray(mem.periods) && mem.periods.length > 0 ? (
+          <Period>
+            {mem.periods
+              .map(
+                p =>
+                  `${p.startYear} ${p.startSeason}${p.endSeason && p.endYear ? ` - ${p.endYear} ${p.endSeason}` : ''}`
+              )
+              .join(' / ')}
+          </Period>
+        ) : (
+          <Period>
+            {mem.startSeason} {mem.startYear} {mem.endSeason && mem.endYear ? ` - ${mem.endSeason} ${mem.endYear}` : ''}
+          </Period>
+        )}
         {mem.phdThesis && (
           <ThesisLink
             href={{

--- a/src/data/members.ts
+++ b/src/data/members.ts
@@ -11,6 +11,12 @@ export type KixlabPositionTypes = (typeof KixlabPositions)[number]
 
 export const SeasonTypes = ['Winter', 'Spring', 'Summer', 'Fall'] as const
 export type SeasonType = (typeof SeasonTypes)[number]
+export type Period = {
+  startSeason: SeasonType
+  startYear: number
+  endSeason?: SeasonType
+  endYear?: number
+}
 
 interface Props {
   firstName: string
@@ -26,6 +32,7 @@ interface Props {
   startSeason?: SeasonType
   endYear?: number
   endSeason?: SeasonType
+  periods?: Period[] // For representing multiple separate periods (e.g., multiple internships at KIXLAB)
   isAlumni?: boolean
   affiliation?: string // the affiliation at the time of being at KIXLAB
   currentPosition?: string // for alumni
@@ -1191,6 +1198,10 @@ export const MEMBERS = {
     startSeason: 'Summer',
     endYear: 2023,
     endSeason: 'Fall',
+    periods: [
+      { startYear: 2023, startSeason: 'Summer', endYear: 2023, endSeason: 'Fall' },
+      { startYear: 2025, startSeason: 'Summer' },
+    ],
     affiliation: 'KAIST',
   },
   hainam: {


### PR DESCRIPTION
Modified code to display multiple engagement periods for alumni
- Add `periods: Period[]` to `Member` to represent multiple stints (e.g., multiple internships).
- Update `AlumniCard.tsx` to display joined periods (e.g., "2025 Summer / 2023 Summer - 2023 Winter").
- The previous code still works correctly without periods, ensuring backward compatibility.

<img width="1235" height="221" alt="image" src="https://github.com/user-attachments/assets/7900a845-82f4-4fe6-817d-967ad410224c" />
<img width="649" height="305" alt="image" src="https://github.com/user-attachments/assets/5c41665a-14a3-49e8-aeec-d7407361f01f" />
